### PR TITLE
minBox uses the first pair of points in a tie

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CellPhe
 Title: Toolkit for cell phenotyping from time-lapse videos
-Version: 0.0.0.9000
+Version: 1.0.1
 Authors@R: 
     person(given = "First",
            family = "Last",

--- a/R/extractFeatures.R
+++ b/R/extractFeatures.R
@@ -397,16 +397,15 @@ minBox = function(bc) {
   # FIND MAXIMUM DISTANCE BETWEEN ANY TWO BOUNDARY POINTS
   d = cbind(bc$x, bc$y)
   dd = as.matrix(stats::dist(d))
-  k1 = which(dd == max(dd), arr.ind = T)[1]
-  k2 = which(dd == max(dd), arr.ind = T)[2]
-  keepx1 = bc$x[k1]
-  
-  keepy1 = bc$y[k1]
-  
-  keepx2 = bc$x[k2]
-  
-  keepy2 = bc$y[k2]
-  
+  max_index <- which.max(dd)
+  n_points <- length(bc$x)
+  row <- (max_index-1) %% n_points + 1
+  col <- floor((max_index-1) / n_points) + 1
+  keepx1 <- bc$x[row]
+  keepy1 <- bc$y[row]
+  keepx2 <- bc$x[col]
+  keepy2 <- bc$y[col]
+
   alpha = atan2((keepy1 - keepy2), (keepx1 - keepx2))
   # rotating points by -alpha makes keepx1-keepx2 lie along x-axis
   roty = keepy1 - sin(alpha) * (bc$x - keepx1) + cos(alpha) * (bc$y - keepy1)

--- a/tests/benchmark.R
+++ b/tests/benchmark.R
@@ -86,8 +86,8 @@ comparison <- sapply(cols_to_compare, function(col) {
 
 # The only failure is density and Cooc02 features, as we changed Density calculation
 # and CoocO2 was incorrectly returning wrong value before
-cat(sprintf("Columns have the same feature values after accounting for the 14 Cooc02 and 1 Density features that have had bug-fixes (%d/%d)\n", sum(comparison), length(comparison)))
-assertthat::are_equal(sum(comparison), 57)
+cat(sprintf("Columns have the same feature values after accounting for fixes to Cooc02 (14 features), Density, minBox (2), minBox:Area, rectangularity (%d/%d)\n", sum(comparison), length(comparison)))
+res <- assertthat::are_equal(sum(comparison), 53)
 results <- c(results, res)
 res
 
@@ -109,11 +109,9 @@ comparison <- sapply(colnames(tsvariables), function(col) {
   assertthat::are_equal(tsvariables[[col]], old_ts[, col])
 })
 
-# The only failure is density and Cooc02 derived features,
-# but again this is Cooc02 had a bug and Density calculation was changed
 cat("\nvarsFromTimeSeries\n~~~~~~~~~~~~~~~~~~\n")
-cat(sprintf("Columns have the same feature values after accounting for the 15 features (x15 time-series variables) that have had bug-fixes (%d/%d)\n", sum(comparison), length(comparison)))
-assertthat::are_equal(sum(comparison), 887)
+cat(sprintf("Columns have the same feature values after accounting for the 19 features (x15 time-series variables) that have had bug-fixes (%d/%d)\n", sum(comparison), length(comparison)))
+res <- assertthat::are_equal(sum(comparison), 828)
 results <- c(results, res)
 res
 


### PR DESCRIPTION
minBox calculates the pairwise distance between all coordinates to find the minimum enclosing box. Previously the way in which the coordinate pair was determined in case of a tie in the pairwise distances was undetermined. The function has been rewritten so that it is now the first pair with the maximum distance that is chosen.