### PR TITLE
Add tolerance when taking floor in cooccurrence matrix

### DIFF
--- a/R/extractFeatures.R
+++ b/R/extractFeatures.R
@@ -595,8 +595,8 @@ getCoocMatrix = function(image1, image2, mask, nc) {
   image2 = rescale(image2, nc)
   cooc = matrix(0, nrow = nc, ncol = nc)
   masked <- mask == 1
-  xs <- floor(image1[masked])
-  ys <- floor(image2[masked])
+  xs <- floor(image1[masked]+1e-6)
+  ys <- floor(image2[masked]+1e-6)
   positive_coordinates <- xs > 0 & ys > 0
   flattened <- xs[positive_coordinates] + nc * (ys[positive_coordinates] - 1)
   counts <- tabulate(flattened)


### PR DESCRIPTION
The rescaling can result in values that mathematically should be equal to whole integers, say 4, but when stored as floating point numbers it can be 3.99999999999996, which when floored will round down to 3, when it should be 4.
This commit fixes this behaviour by adding a small tolerance to the pixel value before flooring.