### PR TITLE
fix to trajectory area denominator

### DIFF
--- a/R/extractFeatures.R
+++ b/R/extractFeatures.R
@@ -728,13 +728,11 @@ densityCalc = function(df, radius_threshold=6) {
     dplyr::ungroup()
 }
 
-calculateTrajArea <- function(x, y)
+calculateTrajArea <- function(x, y, numframes)
 {
   xCentres <- stats::na.omit(x)
   yCentres <- stats::na.omit(y)
-  numframes = length(xCentres)
-  trajArea = ((max(xCentres) - min(xCentres)) * (max(yCentres) - min(yCentres))) /
-    numframes
+  trajArea = ((max(xCentres) - min(xCentres)) * (max(yCentres) - min(yCentres))) / numframes
   return(trajArea)
 }
 

--- a/R/varsFromTimeSeries.R
+++ b/R/varsFromTimeSeries.R
@@ -68,7 +68,11 @@ varsFromTimeSeries = function(df) {
     vars = rbind(stats, eleVars, wVars)
     output[j, 1] <- cell_id
     output[j, 2:(numcols - 1)] = as.vector(vars)
-    output[j, numcols] = calculateTrajArea(df$xpos[df$CellID == cell_id], df$ypos[df$CellID == cell_id])
+    output[j, numcols] = calculateTrajArea(
+        df$xpos[df$CellID == cell_id],
+        df$ypos[df$CellID == cell_id],
+        max(frame_ids) - min(frame_ids) + 1
+    )
   }
   cn = colnames(vars)
   rn = c(


### PR DESCRIPTION
The denominator is the number of frames that a cell appeared in to normalise the area covered to the duration of the cell being tracked. Previously this didn't take interpolated frames into account. I.e. if a cell appeared in frames 1, 2, 3, (missing), 6, 7, 8, the denominator would be 6, rather than the 8 frames that the cell was actually moving for. This commit fixes this