### PR TITLE
feat: balanced training set for segmentation classification

### DIFF
--- a/R/predictSegErrors.R
+++ b/R/predictSegErrors.R
@@ -19,18 +19,18 @@ predictSegErrors<-function(segerrors, correctsegs,
                            num, testset, dataID, proportion) 
 { 
   seginfo<-prepareSegmentationTrainingSet(segerrors, correctsegs)
-  smalldata = seginfo[[1]]
-  bigdata = seginfo[[2]]
-  smallclass = seginfo[[3]]
-  bigclass = seginfo[[4]]
-  n1 = length(smallclass)
-  n2 = length(bigclass)
+  smalldata = seginfo$minority_data
+  bigdata = seginfo$majority_data
+  smallclass = seginfo$minority_class
+  bigclass = seginfo$majority_class
+  n1 = nrow(smalldata)
+  n2 = nrow(bigdata)
   treelist = list()
   for (i in 1:num)
   { 
     inds = sample.int(n2, n1)
     data = rbind(bigdata[inds,],smalldata)
-    class = c(bigclass[1:n1], smallclass)
+    class = c(rep(bigclass, n1), rep(smallclass, n1))
     data = data.frame(class, data)
     mytree = tree::tree(as.factor(class)~., data=data)
     treelist[[i]] <- mytree 

--- a/R/predictSegErrors.R
+++ b/R/predictSegErrors.R
@@ -11,14 +11,16 @@
 #' @param testset Test set for segmentation error predictions to be made
 #' @param dataID List of test set identifiers (e.g. cell IDs)
 #' @param proportion Proportion of votes needed for a final classification of segmentation error to be made (e.g. 0.7 if 70% of the votes are needed for segmentation error classification to be made)
+#' @param dup_size Passed to smotefamily::SMOTE. The number of times to
+#' duplicate the minority class.
 #'
 #' @return This function returns the list of identifiers that were predicted as segmentation errors
 
 #' @export
 predictSegErrors<-function(segerrors, correctsegs,
-                           num, testset, dataID, proportion) 
+                           num, testset, dataID, proportion, dup_size=1)
 { 
-  seginfo<-prepareSegmentationTrainingSet(segerrors, correctsegs)
+  seginfo<-prepareSegmentationTrainingSet(segerrors, correctsegs, dup_size)
   smalldata = seginfo$minority_data
   bigdata = seginfo$majority_data
   smallclass = seginfo$minority_class

--- a/R/predictSegErrors_Ensemble.R
+++ b/R/predictSegErrors_Ensemble.R
@@ -10,15 +10,17 @@
 #' @param testset Test set for segmentation error predictions to be made
 #' @param dataID List of test set identifiers (e.g. cell IDs)
 #' @param proportion Proportion of votes needed for a final classification of segmentation error to be made (e.g. 0.7 if 70% of the votes are needed for segmentation error classification to be made)
+#' @param dup_size Passed to smotefamily::SMOTE. The number of times to
+#' duplicate the minority class.
 #'
 #' @return This function returns the list of identifiers that were predicted as segmentation errors, note these cells will have been predicted a segmentation error in at least \code{K/2} of the repeated classification runs
 #' @export
-predictSegErrors_Ensemble<-function(segerrors, correctsegs, num, K, testset, dataID, proportion) 
+predictSegErrors_Ensemble<-function(segerrors, correctsegs, num, K, testset, dataID, proportion, dup_size)
 { 
   votes<-list()
   for(i in c(1:K))
   {
-    segtest<-predictSegErrors(segerrors, correctsegs, num, testset, dataID, proportion)
+    segtest<-predictSegErrors(segerrors, correctsegs, num, testset, dataID, proportion, dup_size)
     votes[[i]]<-segtest
   }
   

--- a/R/prepareSegmentationTrainingSet.R
+++ b/R/prepareSegmentationTrainingSet.R
@@ -9,9 +9,11 @@
 #'
 #' @param segerrors A feature table of ground truth segmentation errors
 #' @param correctsegs A feature table of ground truth correctly segmented cells
+#' @param dup_size Passed to smotefamily::SMOTE. The number of times to
+#' duplicate the minority class.
 #'
 #' @export
-prepareSegmentationTrainingSet<-function(segerrors,correctsegs)
+prepareSegmentationTrainingSet<-function(segerrors,correctsegs, dup_size=1)
 {
   alldata = rbind(segerrors, correctsegs)[, -1]
   
@@ -21,7 +23,7 @@ prepareSegmentationTrainingSet<-function(segerrors,correctsegs)
   class = c(class1, class2)
   
   ## SMOTE() to over-sample segmentation errors 
-  smoteseg<-smotefamily::SMOTE(alldata, class, K = 3, dup_size = 1)
+  smoteseg<-smotefamily::SMOTE(alldata, class, K = 3, dup_size = dup_size)
   
   ## add smote segmentation errors to the training sets and update segmentation error data table
   smotesegsyn_data<-smoteseg$syn_data[,c((dim(segerrors)[2]), 1:(dim(segerrors)[2]-1))] 

--- a/R/prepareSegmentationTrainingSet.R
+++ b/R/prepareSegmentationTrainingSet.R
@@ -13,30 +13,25 @@
 #' @export
 prepareSegmentationTrainingSet<-function(segerrors,correctsegs)
 {
-  Segerrortraining <- segerrors
-  Correctsegtraining <- correctsegs
-  
-  ## collate correct segmentation and segmentation error data into one data frame
-  data = rbind(Segerrortraining, Correctsegtraining) 
-  segerrordata<-Segerrortraining[,-1] 
-  correctsegdata<-Correctsegtraining[,-1]
-  alldata = rbind(segerrordata, correctsegdata)
+  alldata = rbind(segerrors, correctsegs)[, -1]
   
   ## first column lists ground truth data labels
-  class1 = rep("segerror", dim(segerrordata)[1])
-  class2 = rep("correct", dim(correctsegdata)[1]) 
+  class1 = rep("segerror", nrow(segerrors))
+  class2 = rep("correct", nrow(correctsegs))
   class = c(class1, class2)
-  all = data.frame(class, alldata)
   
   ## SMOTE() to over-sample segmentation errors 
-  smoteseg<-smotefamily::SMOTE(all[,-1], all$class, K = 3, dup_size = 1)
+  smoteseg<-smotefamily::SMOTE(alldata, class, K = 3, dup_size = 1)
   
   ## add smote segmentation errors to the training sets and update segmentation error data table
   smotesegsyn_data<-smoteseg$syn_data[,c((dim(segerrors)[2]), 1:(dim(segerrors)[2]-1))] 
-  all<-rbind(all, smoteseg$syn_data) 
-  segdata<-rbind(segerrordata, smotesegsyn_data[,-1]) 
-  newclass<-c(class, smotesegsyn_data[,1]) 
-  class1 = rep("segerror", dim(segerrordata)[1])
-  seginfo<-list(segerrordata, correctsegdata, class1, class2)
-  return(seginfo)
+  list(
+    minority_data = rbind(
+      smoteseg$orig_P,
+      smoteseg$syn_data
+    )[, -ncol(smoteseg$orig_P)],
+    majority_data=smoteseg$orig_N[, -ncol(smoteseg$orig_N)],
+    minority_class=smoteseg$orig_P$class[1],
+    majority_class=smoteseg$orig_N$class[1]
+  )
 }


### PR DESCRIPTION
Adds the ability to oversample the minority class using SMOTE. The `dup_size` argument to `predictSegError` and `predictSegError_Ensemble` controls how much to oversample by and is passed directly to `smotefamily::SMOTE`.

Does this look ok to you @llwiggins @demonbiddie ?